### PR TITLE
updated launch libinjection code to use prod library on prod host

### DIFF
--- a/scripts/instrument.js
+++ b/scripts/instrument.js
@@ -2,19 +2,17 @@ import { loadScript } from './utils.js';
 
 function loadAdobeLaunch() {
   const { host } = window.location;
+
   let scriptUrl = 'https://assets.adobedtm.com/52be42758645/f4f76a9081b6/launch-bd7785fa0dac-development.min.js';
   if (/\.hlx\.page/.test(host) || /\.hlx\.live/.test(host)) {
     // if on hlx.page or hlx.live upgrade to stage library
     scriptUrl = 'https://assets.adobedtm.com/52be42758645/f4f76a9081b6/launch-37775755caa8-staging.min.js';
   }
 
-  /* commenting out loading prod library for now.
-  if (/rockstar.adobeevents.com/.test(host)
-  || /main--aem-rockstar-website--adobe.hlx.live/.test(host)) {
+  if (/rockstar\.adobeevents\.com/.test(host)) {
     // if on a prod domain, then use the prod library
     scriptUrl = 'https://assets.adobedtm.com/52be42758645/f4f76a9081b6/launch-d4e94ba1de20.min.js';
   }
-  */
 
   loadScript(scriptUrl, null, null, true);
 }


### PR DESCRIPTION
Load prod launch library when on the prod domain.

Test URLs (update as needed):
- Before: https://main--aem-rockstar-website--adobe.hlx.page/en/
- After: https://production-launch-lib--aem-rockstar-website--adobe.hlx.page/en/
